### PR TITLE
fixes issue #7

### DIFF
--- a/dspace-api/src/main/java/cz/cuni/mff/ufal/dspace/discovery/SolrServiceTweaksPlugin.java
+++ b/dspace-api/src/main/java/cz/cuni/mff/ufal/dspace/discovery/SolrServiceTweaksPlugin.java
@@ -105,6 +105,23 @@ public class SolrServiceTweaksPlugin implements SolrServiceIndexPlugin,
                         }
                     }
                 }
+                
+                for (Map.Entry<String, List<DiscoverySearchFilter>> entry : searchFilters
+                        .entrySet())
+                {
+                	//clear any input document fields we are about to add lower
+                    //String metadataField = entry.getKey();
+                    List<DiscoverySearchFilter> filters = entry.getValue();
+                    for (DiscoverySearchFilter filter : filters)
+                    {
+                    	String name = filter.getIndexFieldName();
+                    	String[] names = {name, name + "_filter", name + "_keyword",
+                    			name + "_ac"};
+                    	for(String fieldName : names){
+                    		document.removeField(fieldName);
+                    	}
+                    }
+                }
 
                 for (Map.Entry<String, List<DiscoverySearchFilter>> entry : searchFilters
                         .entrySet())
@@ -175,6 +192,10 @@ public class SolrServiceTweaksPlugin implements SolrServiceIndexPlugin,
                                                     + "_keyword", langName);
                                     document.addField(
                                             filter.getIndexFieldName() + "_ac",
+                                            langName);
+                                    //this should ensure it's copied into the default search field
+                                    document.addField(
+                                            "dc.language.name",
                                             langName);
                                 }
                                 else

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -2220,6 +2220,13 @@ public class SolrServiceImpl implements SearchService, IndexingService {
         }else if(facetFieldConfig.getType().equals(DiscoveryConfigurationParameters.TYPE_STANDARD))
         {
             return field;
+	}else if(facetFieldConfig.getType().equals(DiscoveryConfigurationParameters.TYPE_ISO_LANG)){
+            if(removePostfix)
+            {
+                return field.substring(0, field.lastIndexOf("_filter"));
+            }else{
+                return field + "_filter";
+            }
         }else{
             return field;
         }


### PR DESCRIPTION
search fields tweaks

use _filter for ISO_LANG type

Revert "use _filter for ISO_LANG type"
tried to avoid modifying SolrServiceImpl, but that is somehow cumbersome

This reverts commit e1c67c9555b06af583491ddbcac36ccbe78016eb.

...

...
